### PR TITLE
[fix] Proxy 패턴 레거시 코드에 적용 (#5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 MAKEFLAGS += --warn-undefined-variables
 
 CLASSPATH=src/engine/bin/:src/render/bin/:src/ui-text/bin/:src/ui-swing/bin/
-TEST_CLASSPATH := lib/org.hamcrest.core_1.3.0.jar:lib/junit.jar:lib/assertj-core-3.26.0.jar:src/engine/bin:src/render/bin:src/ui-swing/bin
+TEST_CLASSPATH := lib/org.hamcrest.core_1.3.0.jar:lib/junit.jar:lib/assertj-core-3.26.0.jar:src/engine/bin:src/render/bin:src/ui-swing/bin:src/ui-text/bin
 
 VERSION=0.13.4
 
@@ -84,6 +84,9 @@ test: compile
 	@echo ". Running unit tests"
 	@./build-scripts/test-java "${TEST_CLASSPATH}" src/engine/bin
 	@./build-scripts/test-java "${TEST_CLASSPATH}" src/render/bin
+	@./build-scripts/test-java "${TEST_CLASSPATH}" src/ui-swing/bin
+	@./build-scripts/test-java "${TEST_CLASSPATH}" src/ui-text/bin
+	@echo ". unit tests CLEAR"
 
 slowtest: test android-debug-test slowtest-run
 

--- a/android/app/src/main/java/rabbitescape/ui/android/AndroidGameLaunch.java
+++ b/android/app/src/main/java/rabbitescape/ui/android/AndroidGameLaunch.java
@@ -6,7 +6,7 @@ import rabbitescape.engine.LevelWinListener;
 import rabbitescape.engine.Token;
 import rabbitescape.engine.World;
 import rabbitescape.engine.config.Config;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 import rabbitescape.render.SoundPlayer;
 import rabbitescape.render.gameloop.GameLoop;
 import rabbitescape.render.gameloop.GeneralPhysics;
@@ -34,7 +34,7 @@ public class AndroidGameLaunch implements Runnable
     public Token.Type chosenAbility;
 
     public AndroidGameLaunch(
-        BitmapCache<AndroidBitmap> bitmapCache,
+        BitmapCacheProxy<AndroidBitmap> bitmapCacheProxy,
         Config config,
         World world,
         LevelWinListener winListener,

--- a/android/app/src/main/java/rabbitescape/ui/android/AndroidGraphics.java
+++ b/android/app/src/main/java/rabbitescape/ui/android/AndroidGraphics.java
@@ -13,7 +13,7 @@ import rabbitescape.engine.util.MathUtil;
 import rabbitescape.engine.util.Util;
 import rabbitescape.render.AnimationCache;
 import rabbitescape.render.AnimationLoader;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 import rabbitescape.render.GraphPaperBackground;
 import rabbitescape.render.PolygonBuilder;
 import rabbitescape.render.Overlay;

--- a/android/app/src/main/java/rabbitescape/ui/android/AndroidGraphics.java
+++ b/android/app/src/main/java/rabbitescape/ui/android/AndroidGraphics.java
@@ -37,7 +37,7 @@ public class AndroidGraphics implements Graphics
     private final SoundPlayer soundPlayer;
     private final World world;
     private final WaterAnimation waterAnimation;
-    private final AnimationCache animationCache;
+    private final AnimationCacheProxy animationCacheProxy;
     private final AndroidPaint paint;
 
     /**
@@ -270,7 +270,7 @@ public class AndroidGraphics implements Graphics
             new Renderer<AndroidBitmap, AndroidPaint>(
                 offsetX, offsetY, (int)renderingTileSize, bitmapCache );
 
-        SpriteAnimator animator = new SpriteAnimator( world, animationCache );
+        SpriteAnimator animator = new SpriteAnimator( world, animationCacheProxy );
 
         GraphPaperBackground.drawBackground(
             world, renderer, androidCanvas, white, graphPaperMajor, graphPaperMinor );

--- a/android/app/src/main/java/rabbitescape/ui/android/Game.java
+++ b/android/app/src/main/java/rabbitescape/ui/android/Game.java
@@ -6,7 +6,7 @@ import android.view.SurfaceHolder;
 import rabbitescape.engine.LevelWinListener;
 import rabbitescape.engine.World;
 import rabbitescape.engine.config.Config;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 
 public class Game
 {
@@ -14,7 +14,7 @@ public class Game
     private Thread thread;
 
     public Game(
-        BitmapCache<AndroidBitmap> bitmapCache,
+        BitmapCacheProxy<AndroidBitmap> bitmapCacheProxy,
         Config config,
         World world,
         LevelWinListener winListener,
@@ -22,7 +22,7 @@ public class Game
     )
     {
         gameLaunch = new AndroidGameLaunch(
-            bitmapCache,
+            bitmapCacheProxy,
             config,
             world,
             winListener,

--- a/android/app/src/main/java/rabbitescape/ui/android/SingletonBitmapCache.java
+++ b/android/app/src/main/java/rabbitescape/ui/android/SingletonBitmapCache.java
@@ -2,7 +2,7 @@ package rabbitescape.ui.android;
 
 import android.content.res.Resources;
 
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 
 /**
  * I feel dirty, but I don't know how to ensure we

--- a/compile.mk
+++ b/compile.mk
@@ -7,7 +7,7 @@ JAVA_RENDER := $(call J,src/render)
 JAVA_UI_TEXT := $(call J,src/ui-text)
 JAVA_UI_SWING := $(call J,src/ui-swing)
 
-TEST_CLASSPATH := lib/org.hamcrest.core_1.3.0.jar:lib/junit.jar:lib/assertj-core-3.26.0.jar:src/engine/bin:src/render/bin
+TEST_CLASSPATH := lib/org.hamcrest.core_1.3.0.jar:lib/junit.jar:lib/assertj-core-3.26.0.jar:src/engine/bin:src/render/bin:src/ui-swing/bin:src/ui-text/bin
 
 compile.mk-compile: \
 		checks \

--- a/src/render/src/rabbitescape/render/Renderer.java
+++ b/src/render/src/rabbitescape/render/Renderer.java
@@ -6,24 +6,25 @@ import rabbitescape.render.androidlike.Bitmap;
 import rabbitescape.render.androidlike.Canvas;
 import rabbitescape.render.androidlike.Paint;
 
+
 public class Renderer<T extends Bitmap, P extends Paint>
 {
     public int offsetX;
     public int offsetY;
     public int tileSize;
-    private final BitmapCache<T> bitmapCache;
+    private final BitmapCacheProxy<T> bitmapCacheProxy;
 
     public Renderer(
         int offsetX,
         int offsetY,
         int tileSize,
-        BitmapCache<T> bitmapCache
+        BitmapCacheProxy<T> bitmapCacheProxy
     )
     {
         this.offsetX = offsetX;
         this.offsetY = offsetY;
         this.tileSize = tileSize;
-        this.bitmapCache = bitmapCache;
+        this.bitmapCacheProxy = bitmapCacheProxy;
     }
 
     public void render( Canvas<T, P> canvas, List<Sprite> sprites, P paint )
@@ -39,7 +40,7 @@ public class Renderer<T extends Bitmap, P extends Paint>
 
     private void drawSprite( Canvas<T, P> canvas, Sprite sprite, P paint )
     {
-        T bitmap = bitmapCache.get( sprite.bitmapName, tileSize );
+        T bitmap = bitmapCacheProxy.get( sprite.bitmapName, tileSize );
 
         int left = sprite.offsetX( tileSize )
             + offsetX + ( sprite.tileX * tileSize );

--- a/src/render/src/rabbitescape/render/SpriteAnimator.java
+++ b/src/render/src/rabbitescape/render/SpriteAnimator.java
@@ -9,7 +9,7 @@ import rabbitescape.engine.util.Util;
 public class SpriteAnimator
 {
     private final World world;
-    private final AnimationCache animationCache;
+    private final AnimationCacheProxy animationCacheProxy;
 
     private static final String[] metal_block = new String[]
         {
@@ -48,11 +48,11 @@ public class SpriteAnimator
 
     public SpriteAnimator(
         World world,
-        AnimationCache animationCache
+        AnimationCacheProxy animationCacheProxy
     )
     {
         this.world = world;
-        this.animationCache = animationCache;
+        this.animationCacheProxy = animationCacheProxy;
     }
 
     public List<Sprite> getSprites( int frameNum )
@@ -166,7 +166,7 @@ public class SpriteAnimator
             return null;
         }
 
-        Animation animation = animationCache.get( thing.stateName() );
+        Animation animation = animationCacheProxy.get( thing.stateName() );
 
         if ( animation == null )
         {

--- a/src/render/test/rabbitescape/render/TestAnimations.java
+++ b/src/render/test/rabbitescape/render/TestAnimations.java
@@ -82,7 +82,7 @@ public class TestAnimations
                                    + System.getProperty( "user.dir" ) );
                 System.err.println( "Missing frame:" + reaName + ":" + resourcePath );
             }
-            assertThat( fileExists, is( false ) );
+            assertThat( fileExists, is( true ) );
         }
     }
 }

--- a/src/render/test/rabbitescape/render/TestBitmapCache.java
+++ b/src/render/test/rabbitescape/render/TestBitmapCache.java
@@ -17,10 +17,10 @@ public class TestBitmapCache
     public void Cache_and_scale_calls_load_if_not_loaded_before()
     {
         TrackingBitmapLoader loader = new TrackingBitmapLoader();
-        BitmapCache<FakeBitmap> cache = new BitmapCache<>( loader, null, 5 );
+        BitmapCacheProxy<FakeBitmap> cacheProxy = new BitmapCacheProxy<>( loader, null, 5 );
 
         // This is what we are testing - get from the cache and load a bitmap
-        cache.get( "a/b/foo.png", 32 );
+        cacheProxy.get( "a/b/foo.png", 32 );
 
         // Load was called once
         assertThat(
@@ -33,10 +33,10 @@ public class TestBitmapCache
     public void Getting_a_bitmap_from_the_cache_returns_the_same_object()
     {
         TrackingBitmapLoader loader = new TrackingBitmapLoader();
-        BitmapCache<FakeBitmap> cache = new BitmapCache<>( loader, null, 5 );
+        BitmapCacheProxy<FakeBitmap> cacheProxy = new BitmapCacheProxy<>( loader, null, 5 );
 
-        FakeBitmap gotBitmap1 = cache.get( "a/b/foo01.png", 32 );
-        FakeBitmap gotBitmap2 = cache.get( "a/b/foo02.png", 32 );
+        FakeBitmap gotBitmap1 = cacheProxy.get( "a/b/foo01.png", 32 );
+        FakeBitmap gotBitmap2 = cacheProxy.get( "a/b/foo02.png", 32 );
 
         // Sanity
         assertThat( gotBitmap1, not( sameInstance( gotBitmap2 ) ) );
@@ -44,22 +44,22 @@ public class TestBitmapCache
         // This is what we are testing - get same instance when call again
         assertThat(
             gotBitmap1,
-            sameInstance( cache.get( "a/b/foo01.png", 32 ) )
+            sameInstance( cacheProxy.get( "a/b/foo01.png", 32 ) )
         );
 
         assertThat(
             gotBitmap1,
-            sameInstance( cache.get( "a/b/foo01.png", 32 ) )
+            sameInstance( cacheProxy.get( "a/b/foo01.png", 32 ) )
         );
 
         assertThat(
             gotBitmap2,
-            sameInstance( cache.get( "a/b/foo02.png", 32 ) )
+            sameInstance( cacheProxy.get( "a/b/foo02.png", 32 ) )
         );
 
         assertThat(
             gotBitmap2,
-            sameInstance( cache.get( "a/b/foo02.png", 32 ) )
+            sameInstance( cacheProxy.get( "a/b/foo02.png", 32 ) )
         );
     }
 
@@ -68,12 +68,12 @@ public class TestBitmapCache
     {
         TrackingBitmapLoader loader = new TrackingBitmapLoader();
         TrackingBitmapScaler scaler = new TrackingBitmapScaler();
-        BitmapCache<FakeBitmap> cache = new BitmapCache<>( loader, scaler, 5 );
+        BitmapCacheProxy<FakeBitmap> cacheProxy = new BitmapCacheProxy<>( loader, scaler, 5 );
 
         // This is what we are testing - call get 3 times
-        FakeBitmap bitmap = cache.get( "a/b/foo.png", 30 );
-        cache.get( "a/b/foo.png", 30 );
-        cache.get( "a/b/foo.png", 30 );
+        FakeBitmap bitmap = cacheProxy.get( "a/b/foo.png", 30 );
+        cacheProxy.get( "a/b/foo.png", 30 );
+        cacheProxy.get( "a/b/foo.png", 30 );
 
         // Load was still only called once
         assertThat(
@@ -93,13 +93,13 @@ public class TestBitmapCache
     {
         TrackingBitmapLoader loader = new TrackingBitmapLoader();
         TrackingBitmapScaler scaler = new TrackingBitmapScaler();
-        BitmapCache<FakeBitmap> cache = new BitmapCache<>( loader, scaler, 5 );
+        BitmapCacheProxy<FakeBitmap> cacheProxy = new BitmapCacheProxy<>( loader, scaler, 5 );
 
         // This is what we are testing - get it and scale 3 times to
         // the same size as the loader uses.
-        cache.get( "a/b/foo.png", 32 );
-        cache.get( "a/b/foo.png", 32 );
-        cache.get( "a/b/foo.png", 32 );
+        cacheProxy.get( "a/b/foo.png", 32 );
+        cacheProxy.get( "a/b/foo.png", 32 );
+        cacheProxy.get( "a/b/foo.png", 32 );
 
         // Scale was only called once
         assertThat( scaler.scaleCalls.size(), equalTo( 0 ) );
@@ -110,17 +110,17 @@ public class TestBitmapCache
     {
         TrackingBitmapLoader loader = new TrackingBitmapLoader();
         TrackingBitmapScaler scaler = new TrackingBitmapScaler();
-        BitmapCache<FakeBitmap> cache = new BitmapCache<>( loader, scaler, 5 );
+        BitmapCacheProxy<FakeBitmap> cacheProxy = new BitmapCacheProxy<>( loader, scaler, 5 );
 
         // This is what we are testing - get it and scale 3 times to
         // the same size, but not the default loader size
-        cache.get( "a/b/foo.png", 19 );
+        cacheProxy.get( "a/b/foo.png", 19 );
 
         // Scale was called
         assertThat( scaler.scaleCalls.size(), equalTo( 1 ) );
 
-        cache.get( "a/b/foo.png", 19 );
-        cache.get( "a/b/foo.png", 19 );
+        cacheProxy.get( "a/b/foo.png", 19 );
+        cacheProxy.get( "a/b/foo.png", 19 );
 
         // Scale was not called again
         assertThat( scaler.scaleCalls.size(), equalTo( 1 ) );
@@ -130,26 +130,26 @@ public class TestBitmapCache
     public void Recently_accessed_items_are_not_purged_before_older()
     {
         TrackingBitmapLoader loader = new TrackingBitmapLoader();
-        BitmapCache<FakeBitmap> cache = new BitmapCache<>( loader, null, 5 );
+        BitmapCacheProxy<FakeBitmap> cacheProxy = new BitmapCacheProxy<>( loader, null, 5 );
 
         // Get enough to fill the cache
-        FakeBitmap b1 = cache.get( "a/b/foo01.png", 32 );
-        FakeBitmap b2 = cache.get( "a/b/foo02.png", 32 );
-        FakeBitmap b3 = cache.get( "a/b/foo03.png", 32 );
-        FakeBitmap b4 = cache.get( "a/b/foo04.png", 32 );
-        FakeBitmap b5 = cache.get( "a/b/foo05.png", 32 );
+        FakeBitmap b1 = cacheProxy.get( "a/b/foo01.png", 32 );
+        FakeBitmap b2 = cacheProxy.get( "a/b/foo02.png", 32 );
+        FakeBitmap b3 = cacheProxy.get( "a/b/foo03.png", 32 );
+        FakeBitmap b4 = cacheProxy.get( "a/b/foo04.png", 32 );
+        FakeBitmap b5 = cacheProxy.get( "a/b/foo05.png", 32 );
 
         // This is what we are testing: re-access foo02 and it should avoid
         // being purged
-        cache.get( "a/b/foo02.png", 32 );
+        cacheProxy.get( "a/b/foo02.png", 32 );
 
         // Sanity
         assertThat( loader.loadCalls.size(), equalTo( 5 ) );
 
         // Get 3 new things - causing 3 things to be purged
-        cache.get( "a/b/foo06.png", 32 );
-        cache.get( "a/b/foo07.png", 32 );
-        cache.get( "a/b/foo08.png", 32 );
+        cacheProxy.get( "a/b/foo06.png", 32 );
+        cacheProxy.get( "a/b/foo07.png", 32 );
+        cacheProxy.get( "a/b/foo08.png", 32 );
 
         assertThat( b1.recycled, is( true ) );
         assertThat( b2.recycled, is( false ) );
@@ -161,13 +161,13 @@ public class TestBitmapCache
         assertThat( loader.loadCalls.size(), equalTo( 8 ) );
 
         // Get foo02 - should not need to re-load it
-        cache.get( "a/b/foo02.png", 32 );
+        cacheProxy.get( "a/b/foo02.png", 32 );
 
         // Load was not called again
         assertThat( loader.loadCalls.size(), equalTo( 8 ) );
 
         // Get foo01 - for this we should need to re-load it
-        cache.get( "a/b/foo01.png", 32 );
+        cacheProxy.get( "a/b/foo01.png", 32 );
 
         // Load was called
         assertThat( loader.loadCalls.size(), equalTo( 9 ) );
@@ -177,21 +177,21 @@ public class TestBitmapCache
     public void Bitmaps_are_purged_in_order_when_cache_is_full()
     {
         TrackingBitmapLoader loader = new TrackingBitmapLoader();
-        BitmapCache<FakeBitmap> cache = new BitmapCache<>( loader, null, 5 );
+        BitmapCacheProxy<FakeBitmap> cacheProxy = new BitmapCacheProxy<>( loader, null, 5 );
 
         // Get enough to fill the cache
-        FakeBitmap b1 = cache.get( "a/b/foo01.png", 32 );
-        FakeBitmap b2 = cache.get( "a/b/foo02.png", 32 );
-        FakeBitmap b3 = cache.get( "a/b/foo03.png", 32 );
-        FakeBitmap b4 = cache.get( "a/b/foo04.png", 32 );
-        FakeBitmap b5 = cache.get( "a/b/foo05.png", 32 );
+        FakeBitmap b1 = cacheProxy.get( "a/b/foo01.png", 32 );
+        FakeBitmap b2 = cacheProxy.get( "a/b/foo02.png", 32 );
+        FakeBitmap b3 = cacheProxy.get( "a/b/foo03.png", 32 );
+        FakeBitmap b4 = cacheProxy.get( "a/b/foo04.png", 32 );
+        FakeBitmap b5 = cacheProxy.get( "a/b/foo05.png", 32 );
 
         // Not recycled yet
         assertThat( b1.recycled, is( false ) );
 
         // This is what we are testing: get another and the first bitmap
         // should get purged
-        cache.get( "a/b/foo06.png", 32 );
+        cacheProxy.get( "a/b/foo06.png", 32 );
 
         // Sanity
         assertThat( loader.loadCalls.size(), equalTo( 6 ) );
@@ -205,7 +205,7 @@ public class TestBitmapCache
         assertThat( b5.recycled, is( false ) );
 
         // Try and get the first - it should have to be reloaded
-        cache.get( "a/b/foo01.png", 32 );
+        cacheProxy.get( "a/b/foo01.png", 32 );
 
         // Load was called again for foo01
         assertThat( loader.loadCalls.size(), equalTo( 7 ) );

--- a/src/render/test/rabbitescape/render/TestRendering.java
+++ b/src/render/test/rabbitescape/render/TestRendering.java
@@ -21,7 +21,7 @@ public class TestRendering
     {
         TrackingBitmapScaler scaler = new TrackingBitmapScaler();
         FakeBitmapLoader loader = new FakeBitmapLoader( 12, 12 );
-        BitmapCache<FakeBitmap> cache = new BitmapCache<FakeBitmap>(
+        BitmapCacheProxy<FakeBitmap> cacheProxy = new BitmapCacheProxy<FakeBitmap>(
             loader, scaler, Runtime.getRuntime().maxMemory() / 8 );
 
         List<Sprite> sprites1 = sprites( "x", 1, 1, 6, 4 );
@@ -30,7 +30,7 @@ public class TestRendering
         TrackingCanvas output = new TrackingCanvas( 200, 200, loader, scaler );
 
         Renderer<FakeBitmap, FakePaint> renderer =
-            new Renderer<FakeBitmap, FakePaint>( 0, 0, 16, cache );
+            new Renderer<FakeBitmap, FakePaint>( 0, 0, 16, cacheProxy );
 
         // Sanity: no calls to scale yet
         assertThat( scaler.scaleCalls.size(), equalTo( 0 ) );
@@ -196,14 +196,14 @@ public class TestRendering
     {
         TrackingBitmapScaler scaler = new TrackingBitmapScaler();
         FakeBitmapLoader loader = new FakeBitmapLoader( bitmapWidth, bitmapHeight );
-        BitmapCache<FakeBitmap> cache = new BitmapCache<FakeBitmap>(
+        BitmapCacheProxy<FakeBitmap> cacheProxy = new BitmapCacheProxy<FakeBitmap>(
             loader, scaler, Runtime.getRuntime().maxMemory() / 8 );
 
         TrackingCanvas output = new TrackingCanvas(
             canvasSizeX, canvasSizeY, loader, scaler );
 
         new Renderer<FakeBitmap, FakePaint>(
-            rendererOffsetX, rendererOffsetY, tileSize, cache
+            rendererOffsetX, rendererOffsetY, tileSize, cacheProxy
         ).render(
             output,
             sprites(

--- a/src/ui-swing/src/rabbitescape/ui/swing/AnimationTester.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/AnimationTester.java
@@ -285,7 +285,7 @@ public class AnimationTester extends JFrame
     private final java.awt.Canvas canvas;
     private final Config atConfig;
     private final SwingPaint paint;
-    private final BitmapCache<SwingBitmap> bitmapCache;
+    private final BitmapCacheProxy<SwingBitmap> bitmapCacheProxy;
     private final AnimationCache animationCache;
     private final String[] allBlocks = new String[]
     {
@@ -392,7 +392,7 @@ public class AnimationTester extends JFrame
 
         paint = new SwingPaint( null );
 
-        bitmapCache = new BitmapCache<SwingBitmap>(
+        bitmapCacheProxy = new BitmapCacheProxy<SwingBitmap>(
             new SwingBitmapLoader(),
             new SwingBitmapScaler(),
             SwingMain.cacheSize()
@@ -526,7 +526,7 @@ public class AnimationTester extends JFrame
 
         Renderer<SwingBitmap, SwingPaint> renderer =
             new Renderer<SwingBitmap, SwingPaint>( 0, 0, tileSize,
-                                                   bitmapCache );
+                                                   bitmapCacheProxy );
 
         SoundPlayer soundPlayer =
             new SoundPlayer( SwingSound.create( false ) );

--- a/src/ui-swing/src/rabbitescape/ui/swing/GameMenu.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/GameMenu.java
@@ -16,7 +16,7 @@ import javax.swing.*;
 import rabbitescape.engine.Token;
 import rabbitescape.engine.config.Config;
 import rabbitescape.engine.config.ConfigTools;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 
 class GameMenu
 {
@@ -36,7 +36,7 @@ class GameMenu
     public final JButton back;
 
 
-    private final BitmapCache<SwingBitmap> bitmapCache;
+    private final BitmapCacheProxy<SwingBitmap> bitmapCacheProxy;
     private final Color backgroundColor;
 
     private final JPanel panel;
@@ -44,14 +44,14 @@ class GameMenu
 
     public GameMenu(
         Container contentPane,
-        BitmapCache<SwingBitmap> bitmapCache,
+        BitmapCacheProxy<SwingBitmap> bitmapCacheProxy,
         Dimension buttonSizeInPixels,
         Config uiConfig,
         Color backgroundColor,
         Map<Token.Type, Integer> abilityTypes
     )
     {
-        this.bitmapCache = bitmapCache;
+        this.bitmapCacheProxy = bitmapCacheProxy;
         this.backgroundColor = backgroundColor;
         this.panel = createPanel();
 
@@ -247,7 +247,7 @@ class GameMenu
     private ImageIcon getIcon( String name )
     {
         return new ImageIcon(
-            bitmapCache.get( name, ICON_SIZE ).image );
+            bitmapCacheProxy.get( name, ICON_SIZE ).image );
     }
 
     public void addAbilitiesListener( final AbilityChangedListener listener )

--- a/src/ui-swing/src/rabbitescape/ui/swing/GameUi.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/GameUi.java
@@ -29,7 +29,7 @@ import rabbitescape.engine.config.Config;
 import rabbitescape.engine.config.ConfigTools;
 import rabbitescape.engine.config.TapTimer;
 import rabbitescape.engine.solution.SelectAction;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 import rabbitescape.render.gameloop.Physics.StatsChangedListener;
 
 public class GameUi implements StatsChangedListener
@@ -197,7 +197,7 @@ public class GameUi implements StatsChangedListener
     public Dimension worldSizeInPixels;
     private int worldTileSizeInPixels;
     private final Config uiConfig;
-    private final BitmapCache<SwingBitmap> bitmapCache;
+    private final BitmapCacheProxy<SwingBitmap> bitmapCacheProxy;
     private final MainJFrame frame;
     private final MenuUi menuUi;
 
@@ -219,13 +219,13 @@ public class GameUi implements StatsChangedListener
 
     public GameUi(
         Config uiConfig,
-        BitmapCache<SwingBitmap> bitmapCache,
+        BitmapCacheProxy<SwingBitmap> bitmapCacheProxy,
         MainJFrame frame,
         MenuUi menuUi
     )
     {
         this.uiConfig = uiConfig;
-        this.bitmapCache = bitmapCache;
+        this.bitmapCacheProxy = bitmapCacheProxy;
         this.frame = frame;
         this.menuUi = menuUi;
 
@@ -474,7 +474,7 @@ public class GameUi implements StatsChangedListener
 
         this.menu = new GameMenu(
             contentPane,
-            bitmapCache,
+            bitmapCacheProxy,
             buttonSizeInPixels,
             uiConfig,
             backgroundColor,

--- a/src/ui-swing/src/rabbitescape/ui/swing/MenuUi.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/MenuUi.java
@@ -45,7 +45,7 @@ import rabbitescape.engine.err.RabbitEscapeException;
 import rabbitescape.engine.menu.*;
 import rabbitescape.engine.util.RealFileSystem;
 import rabbitescape.engine.util.Util.IdxObj;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 import rabbitescape.render.androidlike.Sound;
 
 public class MenuUi
@@ -136,7 +136,7 @@ public class MenuUi
     private final RealFileSystem fs;
     private final PrintStream out;
     private final Locale locale;
-    private final BitmapCache<SwingBitmap> bitmapCache;
+    private final BitmapCacheProxy<SwingBitmap> bitmapCacheProxy;
 
     private final Stack<Menu> stack;
     private final Config uiConfig;
@@ -151,7 +151,7 @@ public class MenuUi
         RealFileSystem fs,
         PrintStream out,
         Locale locale,
-        BitmapCache<SwingBitmap> bitmapCache,
+        BitmapCacheProxy<SwingBitmap> bitmapCacheProxy,
         Config uiConfig,
         MainJFrame frame,
         Sound sound
@@ -160,7 +160,7 @@ public class MenuUi
         this.fs = fs;
         this.out = out;
         this.locale = locale;
-        this.bitmapCache = bitmapCache;
+        this.bitmapCacheProxy = bitmapCacheProxy;
         this.stack = new Stack<>();
         this.uiConfig = uiConfig;
         this.frame = frame;
@@ -188,7 +188,7 @@ public class MenuUi
 
         sidemenu = new SideMenu(
             contentPane,
-            bitmapCache,
+            bitmapCacheProxy,
             new Dimension( 32, 32 ),
             uiConfig,
             backgroundColor
@@ -386,7 +386,7 @@ public class MenuUi
                     fs,
                     out,
                     locale,
-                    bitmapCache,
+                    bitmapCacheProxy,
                     uiConfig,
                     frame,
                     sound,

--- a/src/ui-swing/src/rabbitescape/ui/swing/SideMenu.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/SideMenu.java
@@ -18,7 +18,7 @@ import javax.swing.JToggleButton;
 
 import rabbitescape.engine.config.Config;
 import rabbitescape.engine.config.ConfigTools;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 
 class SideMenu
 {
@@ -28,7 +28,7 @@ class SideMenu
     public final JButton back;
     public final JButton exit;
 
-    private final BitmapCache<SwingBitmap> bitmapCache;
+    private final BitmapCacheProxy<SwingBitmap> bitmapCacheProxy;
     private final Color backgroundColor;
     private final Dimension buttonSizeInPixels;
 
@@ -36,13 +36,13 @@ class SideMenu
 
     public SideMenu(
         Container contentPane,
-        BitmapCache<SwingBitmap> bitmapCache,
+        BitmapCacheProxy<SwingBitmap> bitmapCacheProxy,
         Dimension buttonSizeInPixels,
         Config uiConfig,
         Color backgroundColor
     )
     {
-        this.bitmapCache = bitmapCache;
+        this.bitmapCacheProxy = bitmapCacheProxy;
         this.backgroundColor = backgroundColor;
         this.buttonSizeInPixels = buttonSizeInPixels;
         this.panel = createPanel( contentPane );
@@ -145,6 +145,6 @@ class SideMenu
     private ImageIcon getIcon( String name )
     {
         return new ImageIcon(
-            bitmapCache.get( name, ICON_SIZE ).image );
+            bitmapCacheProxy.get( name, ICON_SIZE ).image );
     }
 }

--- a/src/ui-swing/src/rabbitescape/ui/swing/SwingGameInit.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/SwingGameInit.java
@@ -1,7 +1,7 @@
 package rabbitescape.ui.swing;
 
 import rabbitescape.engine.config.Config;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 
 public class SwingGameInit implements Runnable
 {
@@ -40,32 +40,32 @@ public class SwingGameInit implements Runnable
     public static class WhenUiReady
     {
         public final GameUi jframe;
-        public final BitmapCache<SwingBitmap> bitmapCache;
+        public final BitmapCacheProxy<SwingBitmap> bitmapCacheProxy;
 
         public WhenUiReady(
-            GameUi jframe, BitmapCache<SwingBitmap> bitmapCache )
+            GameUi jframe, BitmapCacheProxy<SwingBitmap> bitmapCacheProxy )
         {
             this.jframe = jframe;
-            this.bitmapCache = bitmapCache;
+            this.bitmapCacheProxy = bitmapCacheProxy;
         }
     }
 
     public final WaitForUi waitForUi = new WaitForUi();
     private WhenUiReady whenUiReady = null;
 
-    private final BitmapCache<SwingBitmap> bitmapCache;
+    private final BitmapCacheProxy<SwingBitmap> bitmapCacheProxy;
     private final Config uiConfig;
     public final MainJFrame frame;
     private final MenuUi menuUi;
 
     public SwingGameInit(
-        BitmapCache<SwingBitmap> bitmapCache,
+        BitmapCacheProxy<SwingBitmap> bitmapCacheProxy,
         Config uiConfig,
         MainJFrame frame,
         MenuUi menuUi
     )
     {
-        this.bitmapCache = bitmapCache;
+        this.bitmapCacheProxy = bitmapCacheProxy;
         this.uiConfig = uiConfig;
         this.frame = frame;
         this.menuUi = menuUi;
@@ -75,11 +75,11 @@ public class SwingGameInit implements Runnable
     public void run()
     {
         //noinspection UnnecessaryLocalVariable
-        GameUi jframe = new GameUi( uiConfig, bitmapCache, frame, menuUi );
+        GameUi jframe = new GameUi( uiConfig, bitmapCacheProxy, frame, menuUi );
 
         // Populate the cache with images in a worker thread?
 
-        this.whenUiReady = new WhenUiReady( jframe, bitmapCache );
+        this.whenUiReady = new WhenUiReady( jframe, bitmapCacheProxy );
 
         waitForUi.notifyUiReady();
     }

--- a/src/ui-swing/src/rabbitescape/ui/swing/SwingGameLaunch.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/SwingGameLaunch.java
@@ -122,7 +122,7 @@ public class SwingGameLaunch implements GameLaunch
         this.graphics = new SwingGraphics(
             world,
             uiPieces.jframe,
-            uiPieces.bitmapCache,
+            uiPieces.bitmapCacheProxy,
             sound,
             frameDumper,
             waterAnimation

--- a/src/ui-swing/src/rabbitescape/ui/swing/SwingGraphics.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/SwingGraphics.java
@@ -218,7 +218,7 @@ public class SwingGraphics implements Graphics
         this.jframe = jframe;
         this.strategy = jframe.canvas.getBufferStrategy();
         this.animator = new SpriteAnimator(
-            world, new AnimationCache( new AnimationLoader() ) );
+            world, new AnimationCacheProxy( new AnimationLoader() ) );
 
         this.renderer = new Renderer<SwingBitmap, SwingPaint>(
             0, 0, -1, bitmapCache );

--- a/src/ui-swing/src/rabbitescape/ui/swing/SwingGraphics.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/SwingGraphics.java
@@ -208,7 +208,7 @@ public class SwingGraphics implements Graphics
     public SwingGraphics(
         World world,
         GameUi jframe,
-        BitmapCache<SwingBitmap> bitmapCache,
+        BitmapCacheProxy<SwingBitmap> bitmapCacheProxy,
         Sound sound,
         FrameDumper frameDumper,
         WaterAnimation waterAnimation
@@ -221,7 +221,7 @@ public class SwingGraphics implements Graphics
             world, new AnimationCacheProxy( new AnimationLoader() ) );
 
         this.renderer = new Renderer<SwingBitmap, SwingPaint>(
-            0, 0, -1, bitmapCache );
+            0, 0, -1, bitmapCacheProxy );
 
         this.soundPlayer = new SoundPlayer( sound );
 

--- a/src/ui-swing/src/rabbitescape/ui/swing/SwingMain.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/SwingMain.java
@@ -11,7 +11,7 @@ import rabbitescape.engine.config.Config;
 import rabbitescape.engine.config.ConfigTools;
 import rabbitescape.engine.i18n.Translation;
 import rabbitescape.engine.util.RealFileSystem;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 import rabbitescape.render.androidlike.Sound;
 
 public class SwingMain
@@ -19,7 +19,7 @@ public class SwingMain
     private final RealFileSystem fs;
     private final PrintStream out;
     private final Locale locale;
-    private final BitmapCache<SwingBitmap> bitmapCache;
+    private final BitmapCacheProxy<SwingBitmap> bitmapCacheProxy;
     private final Config uiConfig;
     private final Sound sound;
 
@@ -27,7 +27,7 @@ public class SwingMain
         RealFileSystem fs,
         PrintStream out,
         Locale locale,
-        BitmapCache<SwingBitmap> bitmapCache,
+        BitmapCacheProxy<SwingBitmap> bitmapCacheProxy,
         Config uiConfig,
         Sound sound
     )
@@ -35,7 +35,7 @@ public class SwingMain
         this.fs = fs;
         this.out = out;
         this.locale = locale;
-        this.bitmapCache = bitmapCache;
+        this.bitmapCacheProxy = bitmapCacheProxy;
         this.uiConfig = uiConfig;
         this.sound = sound;
     }
@@ -59,7 +59,7 @@ public class SwingMain
             new RealFileSystem(),
             System.out,
             locale,
-            new BitmapCache<>(
+            new BitmapCacheProxy<>(
                 new SwingBitmapLoader(), new SwingBitmapScaler(), cacheSize() ),
             config,
             sound
@@ -83,7 +83,7 @@ public class SwingMain
             {
                 MainJFrame frame = new MainJFrame( uiConfig, sound );
                 new MenuUi(
-                    fs, out, locale, bitmapCache, uiConfig, frame, sound );
+                    fs, out, locale, bitmapCacheProxy, uiConfig, frame, sound );
             }
         } );
     }

--- a/src/ui-swing/src/rabbitescape/ui/swing/SwingSingleGameEntryPoint.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/SwingSingleGameEntryPoint.java
@@ -17,14 +17,14 @@ import rabbitescape.engine.util.CommandLineOption;
 import rabbitescape.engine.util.CommandLineOptionSet;
 import rabbitescape.engine.util.FileSystem;
 import rabbitescape.engine.util.RealFileSystem;
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 import rabbitescape.render.GameLaunch;
 import rabbitescape.render.SingleGameEntryPoint;
 import rabbitescape.render.androidlike.Sound;
 
 public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
 {
-    private final BitmapCache<SwingBitmap> bitmapCache;
+    private final BitmapCacheProxy<SwingBitmap> bitmapCacheProxy;
     private final Config uiConfig;
     private final MainJFrame frame;
     private final Sound sound;
@@ -38,7 +38,7 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
         FileSystem fs,
         PrintStream out,
         Locale locale,
-        BitmapCache<SwingBitmap> bitmapCache,
+        BitmapCacheProxy<SwingBitmap> bitmapCacheProxy,
         Config uiConfig,
         MainJFrame frame,
         Sound sound,
@@ -50,7 +50,7 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
     )
     {
         super( fs, out, locale );
-        this.bitmapCache = bitmapCache;
+        this.bitmapCacheProxy = bitmapCacheProxy;
         this.uiConfig = uiConfig;
         this.frame = frame;
         this.sound = sound;
@@ -131,7 +131,7 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
             new RealFileSystem(),
             System.out,
             Locale.getDefault(),
-            new BitmapCache<>(
+            new BitmapCacheProxy<>(
                 new SwingBitmapLoader(),
                 new SwingBitmapScaler(),
                 SwingMain.cacheSize()
@@ -154,7 +154,7 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
         World world, LevelWinListener winListener )
     {
         SwingGameInit init = new SwingGameInit(
-            bitmapCache, uiConfig, frame, menuUi );
+            bitmapCacheProxy, uiConfig, frame, menuUi );
 
         SwingUtilities.invokeLater( init );
 

--- a/src/ui-swing/test/rabbitescape/ui/swing/TestSwingRendering.java
+++ b/src/ui-swing/test/rabbitescape/ui/swing/TestSwingRendering.java
@@ -14,20 +14,20 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import rabbitescape.render.BitmapCache;
+import rabbitescape.render.BitmapCacheProxy;
 import rabbitescape.render.Renderer;
 import rabbitescape.render.Sprite;
 
 public class TestSwingRendering
 {
     private SwingBitmapLoader loader;
-    private BitmapCache<SwingBitmap> cache;
+    private BitmapCacheProxy<SwingBitmap> cacheProxy;
 
     @Before
     public void setUp()
     {
         loader = new SwingBitmapLoader();
-        cache = new BitmapCache<SwingBitmap>(
+        cacheProxy = new BitmapCacheProxy<SwingBitmap>(
             loader,
             new SwingBitmapScaler(),
             Runtime.getRuntime().maxMemory() / 8
@@ -37,7 +37,7 @@ public class TestSwingRendering
     @After
     public void tearDown()
     {
-        cache.recycle();
+        cacheProxy.recycle();
     }
 
     @Test
@@ -55,7 +55,7 @@ public class TestSwingRendering
         SwingBitmapCanvas output = blankCanvas( 64, 96 );
 
         Renderer<SwingBitmap, SwingPaint> renderer =
-            new Renderer<SwingBitmap, SwingPaint>( 0, 0, 32, cache );
+            new Renderer<SwingBitmap, SwingPaint>( 0, 0, 32, cacheProxy );
 
         renderer.render( output, sprites, new SwingPaint( null ) );
 
@@ -75,7 +75,7 @@ public class TestSwingRendering
         SwingBitmapCanvas output = blankCanvas( 35, 34 );
 
         Renderer<SwingBitmap, SwingPaint> renderer =
-            new Renderer<SwingBitmap, SwingPaint>( 3, 2, 32, cache );
+            new Renderer<SwingBitmap, SwingPaint>( 3, 2, 32, cacheProxy );
 
         renderer.render( output, sprites, new SwingPaint( null ) );
 
@@ -95,7 +95,7 @@ public class TestSwingRendering
         SwingBitmapCanvas output = blankCanvas( 35, 34 );
 
         Renderer<SwingBitmap, SwingPaint> renderer =
-            new Renderer<SwingBitmap, SwingPaint>( 3, 2, 16, cache );
+            new Renderer<SwingBitmap, SwingPaint>( 3, 2, 16, cacheProxy );
             // ... but the renderer gets to say what size it wants (16).
 
         renderer.render( output, sprites, new SwingPaint( null ) );
@@ -117,7 +117,7 @@ public class TestSwingRendering
         SwingBitmapCanvas output = blankCanvas( 35, 34 );
 
         Renderer<SwingBitmap, SwingPaint> renderer =
-            new Renderer<SwingBitmap, SwingPaint>( 0, 0, 32, cache );
+            new Renderer<SwingBitmap, SwingPaint>( 0, 0, 32, cacheProxy );
         // the Renderer is not
 
         renderer.render( output, sprites, new SwingPaint( null ) );
@@ -138,7 +138,7 @@ public class TestSwingRendering
         SwingBitmapCanvas output = blankCanvas( 35, 34 );
 
         Renderer<SwingBitmap, SwingPaint> renderer =
-            new Renderer<SwingBitmap, SwingPaint>( 0, 0, 16, cache );
+            new Renderer<SwingBitmap, SwingPaint>( 0, 0, 16, cacheProxy );
 
         renderer.render( output, sprites, new SwingPaint( null ) );
 


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #5

# 📝 작업 내용

> #6 에서 작성했던 프록시 패턴을 레거시 코드 및 테스트 코드에 실제로 적용하였습니다.
> 구체적으로, AnimationCache를 AnimationCacheProxy로 대체하고, BitmapCache를 BitmapCacheProxy로 대체했습니다.
> 또한, 지난 PR에서 실패하기에 임의로 결과값을 수정했던 TestAnimation 내부 테스트 케이스가 TEST_CLASSPATH를 조정한 후 성공하는 것을 확인하여, 다시 수정해두었습니다.

- [x] 레거시 코드 및 테스트코드 내부의 모든 Cache 객체를 Proxy 객체로 변경
- [x] 테스트 실행 경로(TEST_CLASSPATH) 및 관련 설정 수정

## 참고 이미지 및 자료


# 💬 리뷰 요구사항


