### PR TITLE
[feat] GithubIssue 클래스에 State 패턴 적용 (#11)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Step 1: Run 'sudo make dist-swing'
+clear
+
+echo "Running 'sudo make dist-swing'..."
+sudo make dist-swing
+if [ $? -ne 0 ]; then
+  echo "Error: 'sudo make dist-swing' failed. Exiting."
+  exit 1
+fi
+
+# Step 2: Run './runrabbit swing'
+echo "Running './runrabbit swing'..."
+./runrabbit swing
+if [ $? -ne 0 ]; then
+  echo "Error: './runrabbit swing' failed. Exiting."
+  exit 1
+fi
+
+echo "Script executed successfully."
+

--- a/src/ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
@@ -64,9 +64,11 @@ public class GitHubIssue
         }
     }
 
-    private void setState(IssueState newState) {
-        this.state = newState;
-        state.handleIssue(this);
+    public void setState(IssueState newState) {
+        if(newState != null) {
+            this.state = newState;
+            state.handleIssue(this);
+        }
     }
 
     // getter/setter 추가

--- a/src/ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
@@ -17,8 +17,6 @@ import rabbitescape.ui.swing.state.DefaultIssueState;
 public class GitHubIssue
 {
     private int number; /** < @brief github issue number. */
-    private boolean isLevel;
-    private boolean isBug;
     private String body = ""; /** < @brief body text excluding world text. */
     private String title;
     /** @brief Worlds are []. These have \n */
@@ -71,15 +69,6 @@ public class GitHubIssue
         }
     }
 
-    // getter/setter 추가
-    public void setIsBug(boolean isBug) {
-        this.isBug = isBug;
-    }
-
-    public void setIsLevel(boolean isLevel) {
-        this.isLevel = isLevel;
-    }
-
     public int getNumber()
     {
         return number;
@@ -87,12 +76,12 @@ public class GitHubIssue
 
     public boolean isLevel()
     {
-        return isLevel;
+        return state.getType().equals("level");
     }
 
     public boolean isBug()
     {
-        return isBug;
+        return state.getType().equals("bug");
     }
 
     /**

--- a/src/ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
@@ -6,6 +6,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import rabbitescape.engine.util.Util;
+import rabbitescape.ui.swing.state.BugIssueState;
+import rabbitescape.ui.swing.state.IssueState;
+import rabbitescape.ui.swing.state.LevelIssueState;
+import rabbitescape.ui.swing.state.DefaultIssueState;
 
 /**
  * @brief encapsulates what has been retrieved about a github issue
@@ -21,6 +25,7 @@ public class GitHubIssue
     private ArrayList<String> wrappedWorlds;
     /** @brief Some issues have multiple worlds: current selected index */
     private int worldIndex = 0;
+    private IssueState state;
 
     private static final String replaceWorldsWith = "\n-----\n";
     private static final String commentSeparator = "\n*****\n";
@@ -38,26 +43,39 @@ public class GitHubIssue
             new String[] {} );
     }
 
-    public GitHubIssue( int gitHubIssueNumber,
+    public GitHubIssue(int gitHubIssueNumber,
         String gitHubIssueTitle,
         String openingCommentBody,
-        String[] labels )
+        String[] labels)
     {
         wrappedWorlds = new ArrayList<String>();
         number = gitHubIssueNumber;
-        addToBody( openingCommentBody );
-        title = stripEscape( gitHubIssueTitle );
-        for ( int i = 0; i < labels.length; i++ )
-        {
-            if ( 0 == labels[i].compareTo( "bug" ) )
-            {
-                isBug = true;
+        addToBody(openingCommentBody);
+        title = stripEscape(gitHubIssueTitle);
+        state = new DefaultIssueState();  // 기본 상태로 시작
+
+        for (String label : labels) {
+            if ("bug".equals(label)) {
+                setState(new BugIssueState());
             }
-            else if ( 0 == labels[i].compareTo( "level" ) )
-            {
-                isLevel = true;
+            else if ("level".equals(label)) {
+                setState(new LevelIssueState());
             }
         }
+    }
+
+    private void setState(IssueState newState) {
+        this.state = newState;
+        state.handleIssue(this);
+    }
+
+    // getter/setter 추가
+    public void setIsBug(boolean isBug) {
+        this.isBug = isBug;
+    }
+
+    public void setIsLevel(boolean isLevel) {
+        this.isLevel = isLevel;
     }
 
     public int getNumber()

--- a/src/ui-swing/src/rabbitescape/ui/swing/state/BugIssueState.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/state/BugIssueState.java
@@ -6,8 +6,6 @@ public class BugIssueState implements IssueState {
     @Override
     public void handleIssue(GitHubIssue issue) {
         // 버그 이슈에 특화된 처리
-        issue.setIsBug(true);
-        issue.setIsLevel(false);
     }
 
     @Override

--- a/src/ui-swing/src/rabbitescape/ui/swing/state/BugIssueState.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/state/BugIssueState.java
@@ -1,0 +1,18 @@
+package rabbitescape.ui.swing.state;
+
+import rabbitescape.ui.swing.GitHubIssue;
+
+public class BugIssueState implements IssueState {
+    @Override
+    public void handleIssue(GitHubIssue issue) {
+        // 버그 이슈에 특화된 처리
+        issue.setIsBug(true);
+        issue.setIsLevel(false);
+    }
+
+    @Override
+    public String getType() {
+        return "bug";
+    }
+}
+

--- a/src/ui-swing/src/rabbitescape/ui/swing/state/DefaultIssueState.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/state/DefaultIssueState.java
@@ -6,8 +6,6 @@ public class DefaultIssueState implements IssueState {
     @Override
     public void handleIssue(GitHubIssue issue) {
         // 기본 상태 처리
-        issue.setIsBug(false);
-        issue.setIsLevel(false);
     }
 
     @Override

--- a/src/ui-swing/src/rabbitescape/ui/swing/state/DefaultIssueState.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/state/DefaultIssueState.java
@@ -1,0 +1,17 @@
+package rabbitescape.ui.swing.state;
+
+import rabbitescape.ui.swing.GitHubIssue;
+
+public class DefaultIssueState implements IssueState {
+    @Override
+    public void handleIssue(GitHubIssue issue) {
+        // 기본 상태 처리
+        issue.setIsBug(false);
+        issue.setIsLevel(false);
+    }
+
+    @Override
+    public String getType() {
+        return "default";
+    }
+}

--- a/src/ui-swing/src/rabbitescape/ui/swing/state/IssueState.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/state/IssueState.java
@@ -1,0 +1,8 @@
+package rabbitescape.ui.swing.state;
+
+import rabbitescape.ui.swing.GitHubIssue;
+
+public interface IssueState {
+    void handleIssue(GitHubIssue issue);
+    String getType();
+}

--- a/src/ui-swing/src/rabbitescape/ui/swing/state/LevelIssueState.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/state/LevelIssueState.java
@@ -6,8 +6,6 @@ public class LevelIssueState implements IssueState {
     @Override
     public void handleIssue(GitHubIssue issue) {
         // 레벨 이슈에 특화된 처리
-        issue.setIsLevel(true);
-        issue.setIsBug(false);
     }
 
     @Override

--- a/src/ui-swing/src/rabbitescape/ui/swing/state/LevelIssueState.java
+++ b/src/ui-swing/src/rabbitescape/ui/swing/state/LevelIssueState.java
@@ -1,0 +1,17 @@
+package rabbitescape.ui.swing.state;
+
+import rabbitescape.ui.swing.GitHubIssue;
+
+public class LevelIssueState implements IssueState {
+    @Override
+    public void handleIssue(GitHubIssue issue) {
+        // 레벨 이슈에 특화된 처리
+        issue.setIsLevel(true);
+        issue.setIsBug(false);
+    }
+
+    @Override
+    public String getType() {
+        return "level";
+    }
+}

--- a/src/ui-swing/test/rabbitescape/ui/swing/TestGitHubIssue.java
+++ b/src/ui-swing/test/rabbitescape/ui/swing/TestGitHubIssue.java
@@ -1,0 +1,105 @@
+package rabbitescape.ui.swing;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+
+import rabbitescape.ui.swing.state.BugIssueState;
+import rabbitescape.ui.swing.state.LevelIssueState;
+import rabbitescape.ui.swing.state.DefaultIssueState;
+
+public class TestGitHubIssue {
+    private GitHubIssue issue;
+    private static final int TEST_ISSUE_NUMBER = 1;
+    private static final String TEST_TITLE = "Test Issue";
+    private static final String TEST_BODY = "Test Body";
+
+    @Before
+    public void setUp() {
+        issue = new GitHubIssue(TEST_ISSUE_NUMBER, TEST_TITLE, TEST_BODY);
+    }
+
+    @Test
+    public void defaultStateTest() {
+        assertThat(issue.isBug()).isFalse();
+        assertThat(issue.isLevel()).isFalse();
+    }
+
+    @Test
+    public void bugStateTest() {
+        // Given
+        GitHubIssue bugIssue = new GitHubIssue(TEST_ISSUE_NUMBER, TEST_TITLE, TEST_BODY, 
+            new String[]{"bug"});
+
+        // Then
+        assertThat(bugIssue.isBug()).isTrue();
+        assertThat(bugIssue.isLevel()).isFalse();
+    }
+
+    @Test
+    public void levelStateTest() {
+        // Given
+        GitHubIssue levelIssue = new GitHubIssue(TEST_ISSUE_NUMBER, TEST_TITLE, TEST_BODY, 
+            new String[]{"level"});
+
+        // Then
+        assertThat(levelIssue.isBug()).isFalse();
+        assertThat(levelIssue.isLevel()).isTrue();
+    }
+
+    @Test
+    public void changeToBugStateTest() {
+        // When
+        issue.setState(new BugIssueState());
+
+        // Then
+        assertThat(issue.isBug()).isTrue();
+        assertThat(issue.isLevel()).isFalse();
+    }
+
+    @Test
+    public void changeToLevelStateTest() {
+        // When
+        issue.setState(new LevelIssueState());
+
+        // Then
+        assertThat(issue.isBug()).isFalse();
+        assertThat(issue.isLevel()).isTrue();
+    }
+
+    @Test
+    public void changeToDefaultStateTest() {
+        // Given
+        issue.setState(new BugIssueState());
+        
+        // When
+        issue.setState(new DefaultIssueState());
+
+        // Then
+        assertThat(issue.isBug()).isFalse();
+        assertThat(issue.isLevel()).isFalse();
+    }
+
+    @Test
+    public void changeToLevelStateWithMultiLabelTest() {
+        // Given
+        GitHubIssue multiLabelIssue = new GitHubIssue(TEST_ISSUE_NUMBER, TEST_TITLE, TEST_BODY, 
+            new String[]{"bug", "level"});
+
+        // Then
+        assertThat(multiLabelIssue.isBug()).isFalse();
+        assertThat(multiLabelIssue.isLevel()).isTrue();
+    }
+
+    @Test
+    public void nullCouldNotChangeStateTest() {
+        // Given
+        issue.setState(new BugIssueState());
+        
+        // When
+        issue.setState(null);
+
+        // Then
+        assertThat(issue.isBug()).isTrue();
+    }
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #11 

구체적인 Background는 Issue 페이지 참고 부탁드립니다.

# 📝 작업 내용
> GithubIssue 클래스에 상태(State) 패턴을 적용하여, 기존에 Issue 종류를 isBug, isLevel 등의 Flag로 구분하던 코드를 정비하였습니다.
> 
> 상태 패턴의 원활한 동작을 확인하기 위해 테스트코드 역시 작성하였습니다. 
> 
> 한편, 현재 코드에서는 Github Issue 관련 UI에 데이터가 뜨지 않는 버그가 있었습니다. (master branch 기준으로도 마찬가지입니다.)
> 
> 파싱 과정에서 문제가 발생하고 있는 것을 확인하여 이를 수정한 결과 정상적으로 데이터가 나타나는 것을 확인했습니다.

- [x] GithubIssue에 State 패턴 적용
- [x] 관련 테스트코드 작성
- [x] 기존 코드 버그(Github Issue 페이지에 데이터가 존재하지 않음) 수정

## 참고 이미지 및 자료
https://inpa.tistory.com/entry/GOF-%F0%9F%92%A0-%EC%83%81%ED%83%9CState-%ED%8C%A8%ED%84%B4-%EC%A0%9C%EB%8C%80%EB%A1%9C-%EB%B0%B0%EC%9B%8C%EB%B3%B4%EC%9E%90

* 기존 Github Issue 페이지
<img width="929" alt="image" src="https://github.com/user-attachments/assets/4d6f3e3c-bbcf-41ce-b2ec-9184c82b565b">

* 버그 수정 후 Github Issue 페이지
<img width="931" alt="image" src="https://github.com/user-attachments/assets/e54b37b1-463a-4cda-83d0-71afd00de514">

# 💬 리뷰 요구사항