### PR TITLE
[feat] World 이벤트 관리에 Observer 패턴 적용

### DIFF
--- a/src/engine/src/rabbitescape/engine/World.java
+++ b/src/engine/src/rabbitescape/engine/World.java
@@ -160,7 +160,6 @@ public class World
         boolean paused,
         Comment[] comments,
         WorldStatsListener statsListener,
-        LevelWinListener winListener,
         VoidMarkerStyle.Style voidStyle
     )
     {
@@ -201,7 +200,7 @@ public class World
 
         this.eventManager = new GameEventManager();
         this.changes = new WorldChanges( this, new WorldStatsListenerAdapter(statsListener, eventManager) );
-        this.levelWinListener = new LevelWinListenerAdapter(winListener, eventManager);
+        this.levelWinListener = null;
 
         init();
     }
@@ -212,7 +211,7 @@ public class World
         List<Rabbit> rabbits,
         List<Thing> things,
         LookupTable2D<WaterRegion> waterTable,
-        Map<rabbitescape.engine.Token.Type, Integer> abilities,
+        Map<Token.Type, Integer> abilities,
         String name,
         String description,
         String author_name,
@@ -229,9 +228,9 @@ public class World
         int rabbit_index_count,
         boolean paused,
         Comment[] comments,
-        IgnoreWorldStatsListener statsListener,
-        LevelWinListener winListener,
-        VoidMarkerStyle.Style voidStyle )
+        WorldStatsListener statsListener,
+        VoidMarkerStyle.Style voidStyle
+    )
     {
         this.size = size;
         this.blockTable = blockTable;
@@ -258,8 +257,8 @@ public class World
         this.voidStyle = voidStyle;
 
         this.eventManager = new GameEventManager();
-        this.changes = new WorldChanges( this, new WorldStatsListenerAdapter(statsListener, eventManager) );
-        this.levelWinListener = new LevelWinListenerAdapter(winListener, eventManager);
+        this.changes = new WorldChanges(this, new WorldStatsListenerAdapter(statsListener, eventManager));
+        this.levelWinListener = null;
 
         init();
     }
@@ -522,6 +521,22 @@ public class World
     }
 
     public void setLevelWinListener(LevelWinListener listener) {
-        this.levelWinListener = new LevelWinListenerAdapter(listener, eventManager);
+        if (listener != null) {
+            this.levelWinListener = new LevelWinListenerAdapter(listener, eventManager);
+        } else {
+            this.levelWinListener = null;
+        }
+    }
+
+    public void won() {
+        if (levelWinListener != null) {
+            levelWinListener.won();
+        }
+    }
+
+    public void lost() {
+        if (levelWinListener != null) {
+            levelWinListener.lost();
+        }
     }
 }

--- a/src/engine/src/rabbitescape/engine/World.java
+++ b/src/engine/src/rabbitescape/engine/World.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import rabbitescape.engine.Rabbit.Type;
 import rabbitescape.engine.WaterRegion;
 import rabbitescape.engine.err.RabbitEscapeException;
+import rabbitescape.engine.events.*;
 import rabbitescape.engine.textworld.Comment;
 import rabbitescape.engine.util.Dimension;
 import rabbitescape.engine.util.LookupTable2D;
@@ -132,6 +133,8 @@ public class World
     public final String music;
     public final VoidMarkerStyle.Style voidStyle;
 
+    private final GameEventManager eventManager;
+
     public World(
         Dimension size,
         List<Block> blocks,
@@ -194,7 +197,8 @@ public class World
                 waterAmounts );
         }
 
-        this.changes = new WorldChanges( this, statsListener );
+        this.eventManager = new GameEventManager();
+        this.changes = new WorldChanges( this, new WorldStatsListenerAdapter(statsListener, eventManager) );
 
         init();
     }
@@ -249,7 +253,8 @@ public class World
         this.comments = comments;
         this.voidStyle = voidStyle;
 
-        this.changes = new WorldChanges( this, statsListener );
+        this.eventManager = new GameEventManager();
+        this.changes = new WorldChanges( this, new WorldStatsListenerAdapter(statsListener, eventManager) );
 
         init();
     }
@@ -497,5 +502,17 @@ public class World
             }
         }
         return waterAmounts;
+    }
+
+    public void addEventListener(EventType type, GameEventListener listener) {
+        eventManager.addEventListener(type, listener);
+    }
+
+    public void removeEventListener(EventType type, GameEventListener listener) {
+        eventManager.removeEventListener(type, listener);
+    }
+
+    public GameEventManager getEventManager() {
+        return eventManager;
     }
 }

--- a/src/engine/src/rabbitescape/engine/World.java
+++ b/src/engine/src/rabbitescape/engine/World.java
@@ -134,6 +134,7 @@ public class World
     public final VoidMarkerStyle.Style voidStyle;
 
     private final GameEventManager eventManager;
+    private LevelWinListener levelWinListener;
 
     public World(
         Dimension size,
@@ -159,6 +160,7 @@ public class World
         boolean paused,
         Comment[] comments,
         WorldStatsListener statsListener,
+        LevelWinListener winListener,
         VoidMarkerStyle.Style voidStyle
     )
     {
@@ -199,6 +201,7 @@ public class World
 
         this.eventManager = new GameEventManager();
         this.changes = new WorldChanges( this, new WorldStatsListenerAdapter(statsListener, eventManager) );
+        this.levelWinListener = new LevelWinListenerAdapter(winListener, eventManager);
 
         init();
     }
@@ -227,6 +230,7 @@ public class World
         boolean paused,
         Comment[] comments,
         IgnoreWorldStatsListener statsListener,
+        LevelWinListener winListener,
         VoidMarkerStyle.Style voidStyle )
     {
         this.size = size;
@@ -255,6 +259,7 @@ public class World
 
         this.eventManager = new GameEventManager();
         this.changes = new WorldChanges( this, new WorldStatsListenerAdapter(statsListener, eventManager) );
+        this.levelWinListener = new LevelWinListenerAdapter(winListener, eventManager);
 
         init();
     }
@@ -514,5 +519,9 @@ public class World
 
     public GameEventManager getEventManager() {
         return eventManager;
+    }
+
+    public void setLevelWinListener(LevelWinListener listener) {
+        this.levelWinListener = new LevelWinListenerAdapter(listener, eventManager);
     }
 }

--- a/src/engine/src/rabbitescape/engine/events/EventType.java
+++ b/src/engine/src/rabbitescape/engine/events/EventType.java
@@ -1,0 +1,14 @@
+package rabbitescape.engine.events;
+
+public enum EventType {
+    RABBIT_MOVED,
+    RABBIT_SAVED,
+    RABBIT_KILLED,
+    TOKEN_ADDED,
+    TOKEN_USED,
+    BLOCK_CHANGED,
+    WATER_CHANGED,
+    LEVEL_WON,
+    LEVEL_LOST,
+    STATS_CHANGED
+}

--- a/src/engine/src/rabbitescape/engine/events/GameEvent.java
+++ b/src/engine/src/rabbitescape/engine/events/GameEvent.java
@@ -1,0 +1,8 @@
+package rabbitescape.engine.events;
+
+import java.util.Map;
+
+public interface GameEvent {
+    EventType getType();
+    Map<String, Object> getEventData();
+}

--- a/src/engine/src/rabbitescape/engine/events/GameEventListener.java
+++ b/src/engine/src/rabbitescape/engine/events/GameEventListener.java
@@ -1,0 +1,5 @@
+package rabbitescape.engine.events;
+
+public interface GameEventListener {
+    void onGameEvent(GameEvent event);
+}

--- a/src/engine/src/rabbitescape/engine/events/GameEventManager.java
+++ b/src/engine/src/rabbitescape/engine/events/GameEventManager.java
@@ -1,0 +1,33 @@
+package rabbitescape.engine.events;
+
+import java.util.*;
+
+public class GameEventManager {
+    private final Map<EventType, List<GameEventListener>> listeners;
+
+    public GameEventManager() {
+        this.listeners = new HashMap<>();
+        for (EventType type : EventType.values()) {
+            listeners.put(type, new ArrayList<>());
+        }
+    }
+
+    public void addEventListener(EventType type, GameEventListener listener) {
+        List<GameEventListener> typeListeners = listeners.get(type);
+        if (!typeListeners.contains(listener)) {
+            typeListeners.add(listener);
+        }
+    }
+
+    public void removeEventListener(EventType type, GameEventListener listener) {
+        List<GameEventListener> typeListeners = listeners.get(type);
+        typeListeners.remove(listener);
+    }
+
+    public void fireEvent(GameEvent event) {
+        List<GameEventListener> typeListeners = listeners.get(event.getType());
+        for (GameEventListener listener : typeListeners) {
+            listener.onGameEvent(event);
+        }
+    }
+}

--- a/src/engine/src/rabbitescape/engine/events/GameEventManager.java
+++ b/src/engine/src/rabbitescape/engine/events/GameEventManager.java
@@ -8,7 +8,7 @@ public class GameEventManager {
     public GameEventManager() {
         this.listeners = new HashMap<>();
         for (EventType type : EventType.values()) {
-            listeners.put(type, new ArrayList<>());
+            listeners.put(type, new ArrayList<GameEventListener>());
         }
     }
 

--- a/src/engine/src/rabbitescape/engine/events/LevelWinEvent.java
+++ b/src/engine/src/rabbitescape/engine/events/LevelWinEvent.java
@@ -1,0 +1,26 @@
+package rabbitescape.engine.events;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LevelWinEvent implements GameEvent {
+    private final EventType type;
+    private final boolean won;
+
+    public LevelWinEvent(boolean won) {
+        this.type = won ? EventType.LEVEL_WON : EventType.LEVEL_LOST;
+        this.won = won;
+    }
+
+    @Override
+    public EventType getType() {
+        return type;
+    }
+
+    @Override
+    public Map<String, Object> getEventData() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("won", won);
+        return data;
+    }
+}

--- a/src/engine/src/rabbitescape/engine/events/LevelWinListenerAdapter.java
+++ b/src/engine/src/rabbitescape/engine/events/LevelWinListenerAdapter.java
@@ -1,0 +1,35 @@
+package rabbitescape.engine.events;
+
+import rabbitescape.engine.LevelWinListener;
+
+public class LevelWinListenerAdapter implements LevelWinListener {
+    private final LevelWinListener originalListener;
+    private final GameEventManager eventManager;
+
+    public LevelWinListenerAdapter(LevelWinListener originalListener, GameEventManager eventManager) {
+        this.originalListener = originalListener;
+        this.eventManager = eventManager;
+    }
+
+    @Override
+    public void won() {
+        // 기존 리스너 호출
+        if (originalListener != null) {
+            originalListener.won();
+        }
+        
+        // 새로운 이벤트 발생
+        eventManager.fireEvent(new LevelWinEvent(true));
+    }
+
+    @Override
+    public void lost() {
+        // 기존 리스너 호출
+        if (originalListener != null) {
+            originalListener.lost();
+        }
+        
+        // 새로운 이벤트 발생
+        eventManager.fireEvent(new LevelWinEvent(false));
+    }
+}

--- a/src/engine/src/rabbitescape/engine/events/RabbitEvent.java
+++ b/src/engine/src/rabbitescape/engine/events/RabbitEvent.java
@@ -1,0 +1,32 @@
+package rabbitescape.engine.events;
+
+import rabbitescape.engine.Rabbit;
+import rabbitescape.engine.util.Position;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RabbitEvent implements GameEvent {
+    private final EventType type;
+    private final Rabbit rabbit;
+    private final Position position;
+
+    public RabbitEvent(EventType type, Rabbit rabbit, Position position) {
+        this.type = type;
+        this.rabbit = rabbit;
+        this.position = position;
+    }
+
+    @Override
+    public EventType getType() {
+        return type;
+    }
+
+    @Override
+    public Map<String, Object> getEventData() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("rabbit", rabbit);
+        data.put("position", position);
+        return data;
+    }
+}

--- a/src/engine/src/rabbitescape/engine/events/StatsChangedEvent.java
+++ b/src/engine/src/rabbitescape/engine/events/StatsChangedEvent.java
@@ -1,0 +1,27 @@
+package rabbitescape.engine.events;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StatsChangedEvent implements GameEvent {
+    private final int numSaved;
+    private final int numToSave;
+
+    public StatsChangedEvent(int numSaved, int numToSave) {
+        this.numSaved = numSaved;
+        this.numToSave = numToSave;
+    }
+
+    @Override
+    public EventType getType() {
+        return EventType.STATS_CHANGED;
+    }
+
+    @Override
+    public Map<String, Object> getEventData() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("numSaved", numSaved);
+        data.put("numToSave", numToSave);
+        return data;
+    }
+}

--- a/src/engine/src/rabbitescape/engine/events/WorldStatsListenerAdapter.java
+++ b/src/engine/src/rabbitescape/engine/events/WorldStatsListenerAdapter.java
@@ -1,0 +1,24 @@
+package rabbitescape.engine.events;
+
+import rabbitescape.engine.WorldStatsListener;
+
+public class WorldStatsListenerAdapter implements WorldStatsListener {
+    private final WorldStatsListener originalListener;
+    private final GameEventManager eventManager;
+
+    public WorldStatsListenerAdapter(WorldStatsListener originalListener, GameEventManager eventManager) {
+        this.originalListener = originalListener;
+        this.eventManager = eventManager;
+    }
+
+    @Override
+    public void worldStats(int numSaved, int numToSave) {
+        // 기존 리스너 호출
+        if (originalListener != null) {
+            originalListener.worldStats(numSaved, numToSave);
+        }
+        
+        // 새로운 이벤트 발생
+        eventManager.fireEvent(new StatsChangedEvent(numSaved, numToSave));
+    }
+}

--- a/src/engine/test/rabbitescape/engine/events/GameEventManagerTest.java
+++ b/src/engine/test/rabbitescape/engine/events/GameEventManagerTest.java
@@ -38,14 +38,15 @@ public class GameEventManagerTest {
     public void addEventListener_shouldAddListener() {
         // Act
         manager.addEventListener(EventType.RABBIT_MOVED, listener);
-        manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
+        TestGameEvent event = new TestGameEvent();
+        event.setTestData("test");
+        manager.fireEvent(event);
         
         // Assert
         assertEquals(1, listener.getReceivedEvents().size());
-        GameEvent event = listener.getReceivedEvents().get(0);
-        assertEquals(EventType.RABBIT_MOVED, event.getType());
-        assertTrue(event.getEventData().containsKey("testData"));
-        assertEquals("test", event.getEventData().get("testData"));
+        GameEvent receivedEvent = listener.getReceivedEvents().get(0);
+        assertEquals(EventType.RABBIT_MOVED, receivedEvent.getType());
+        assertEquals("test", receivedEvent.getEventData().get("testData"));
     }
     
     @Test
@@ -55,7 +56,9 @@ public class GameEventManagerTest {
         
         // Act
         manager.removeEventListener(EventType.RABBIT_MOVED, listener);
-        manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
+        TestGameEvent event = new TestGameEvent();
+        event.setTestData("test");
+        manager.fireEvent(event);
         
         // Assert
         assertEquals(0, listener.getReceivedEvents().size());
@@ -69,7 +72,9 @@ public class GameEventManagerTest {
         manager.addEventListener(EventType.LEVEL_WON, otherListener);
         
         // Act
-        manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
+        TestGameEvent event = new TestGameEvent();
+        event.setTestData("test");
+        manager.fireEvent(event);
         
         // Assert
         assertEquals(1, listener.getReceivedEvents().size());
@@ -84,7 +89,9 @@ public class GameEventManagerTest {
         manager.addEventListener(EventType.RABBIT_MOVED, listener2);
         
         // Act
-        manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
+        TestGameEvent event = new TestGameEvent();
+        event.setTestData("test");
+        manager.fireEvent(event);
         
         // Assert
         assertEquals(1, listener.getReceivedEvents().size());

--- a/src/engine/test/rabbitescape/engine/events/GameEventManagerTest.java
+++ b/src/engine/test/rabbitescape/engine/events/GameEventManagerTest.java
@@ -1,7 +1,6 @@
 package rabbitescape.engine.events;
 
 import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.Before;
 import org.junit.Test;
 import java.util.ArrayList;
@@ -42,10 +41,11 @@ public class GameEventManagerTest {
         manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
         
         // Assert
-        assertThat(listener.getReceivedEvents().size(), is(1));
+        assertEquals(1, listener.getReceivedEvents().size());
         GameEvent event = listener.getReceivedEvents().get(0);
-        assertThat(event.getType(), is(EventType.RABBIT_MOVED));
-        assertThat(event.getEventData().get("testData"), is("test"));
+        assertEquals(EventType.RABBIT_MOVED, event.getType());
+        assertTrue(event.getEventData().containsKey("testData"));
+        assertEquals("test", event.getEventData().get("testData"));
     }
     
     @Test
@@ -58,7 +58,7 @@ public class GameEventManagerTest {
         manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
         
         // Assert
-        assertThat(listener.getReceivedEvents().size(), is(0));
+        assertEquals(0, listener.getReceivedEvents().size());
     }
     
     @Test
@@ -72,8 +72,8 @@ public class GameEventManagerTest {
         manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
         
         // Assert
-        assertThat(listener.getReceivedEvents().size(), is(1));
-        assertThat(otherListener.getReceivedEvents().size(), is(0));
+        assertEquals(1, listener.getReceivedEvents().size());
+        assertEquals(0, otherListener.getReceivedEvents().size());
     }
     
     @Test
@@ -87,7 +87,7 @@ public class GameEventManagerTest {
         manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
         
         // Assert
-        assertThat(listener.getReceivedEvents().size(), is(1));
-        assertThat(listener2.getReceivedEvents().size(), is(1));
+        assertEquals(1, listener.getReceivedEvents().size());
+        assertEquals(1, listener2.getReceivedEvents().size());
     }
 }

--- a/src/engine/test/rabbitescape/engine/events/GameEventManagerTest.java
+++ b/src/engine/test/rabbitescape/engine/events/GameEventManagerTest.java
@@ -1,0 +1,112 @@
+package rabbitescape.engine.events;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GameEventManagerTest {
+    
+    private static class TestEventListener implements GameEventListener {
+        private final List<GameEvent> receivedEvents = new ArrayList<>();
+        
+        @Override
+        public void onGameEvent(GameEvent event) {
+            receivedEvents.add(event);
+        }
+        
+        public List<GameEvent> getReceivedEvents() {
+            return receivedEvents;
+        }
+        
+        public void clearEvents() {
+            receivedEvents.clear();
+        }
+    }
+    
+    @Test
+    public void addEventListener_shouldAddListener() {
+        // Arrange
+        GameEventManager manager = new GameEventManager();
+        TestEventListener listener = new TestEventListener();
+        
+        // Act
+        manager.addEventListener(EventType.RABBIT_MOVED, listener);
+        manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
+        
+        // Assert
+        assertThat(listener.getReceivedEvents().size(), is(1));
+        assertThat(
+            ((TestGameEvent)listener.getReceivedEvents().get(0)).getTestData(),
+            is("test")
+        );
+    }
+    
+    @Test
+    public void removeEventListener_shouldRemoveListener() {
+        // Arrange
+        GameEventManager manager = new GameEventManager();
+        TestEventListener listener = new TestEventListener();
+        manager.addEventListener(EventType.RABBIT_MOVED, listener);
+        
+        // Act
+        manager.removeEventListener(EventType.RABBIT_MOVED, listener);
+        manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
+        
+        // Assert
+        assertThat(listener.getReceivedEvents().size(), is(0));
+    }
+    
+    @Test
+    public void fireEvent_shouldOnlyNotifyListenersOfSpecificType() {
+        // Arrange
+        GameEventManager manager = new GameEventManager();
+        TestEventListener rabbitListener = new TestEventListener();
+        TestEventListener tokenListener = new TestEventListener();
+        
+        manager.addEventListener(EventType.RABBIT_MOVED, rabbitListener);
+        manager.addEventListener(EventType.TOKEN_ADDED, tokenListener);
+        
+        // Act
+        manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "rabbit"));
+        
+        // Assert
+        assertThat(rabbitListener.getReceivedEvents().size(), is(1));
+        assertThat(tokenListener.getReceivedEvents().size(), is(0));
+    }
+    
+    @Test
+    public void fireEvent_shouldNotifyMultipleListeners() {
+        // Arrange
+        GameEventManager manager = new GameEventManager();
+        TestEventListener listener1 = new TestEventListener();
+        TestEventListener listener2 = new TestEventListener();
+        
+        manager.addEventListener(EventType.RABBIT_MOVED, listener1);
+        manager.addEventListener(EventType.RABBIT_MOVED, listener2);
+        
+        // Act
+        manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
+        
+        // Assert
+        assertThat(listener1.getReceivedEvents().size(), is(1));
+        assertThat(listener2.getReceivedEvents().size(), is(1));
+    }
+    
+    @Test
+    public void addEventListener_shouldNotAddSameListenerTwice() {
+        // Arrange
+        GameEventManager manager = new GameEventManager();
+        TestEventListener listener = new TestEventListener();
+        
+        // Act
+        manager.addEventListener(EventType.RABBIT_MOVED, listener);
+        manager.addEventListener(EventType.RABBIT_MOVED, listener);
+        manager.fireEvent(new TestGameEvent(EventType.RABBIT_MOVED, "test"));
+        
+        // Assert
+        assertThat(listener.getReceivedEvents().size(), is(1));
+    }
+}

--- a/src/engine/test/rabbitescape/engine/events/LevelWinListenerAdapterTest.java
+++ b/src/engine/test/rabbitescape/engine/events/LevelWinListenerAdapterTest.java
@@ -1,7 +1,6 @@
 package rabbitescape.engine.events;
 
 import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.Before;
 import org.junit.Test;
 import rabbitescape.engine.LevelWinListener;
@@ -67,13 +66,13 @@ public class LevelWinListenerAdapterTest {
         adapter.won();
         
         // Assert
-        assertThat(originalListener.wonCalled, is(true));
-        assertThat(originalListener.lostCalled, is(false));
+        assertTrue(originalListener.wonCalled);
+        assertFalse(originalListener.lostCalled);
         
         GameEvent event = eventListener.getLastEvent();
-        assertThat(event, is(notNullValue()));
-        assertThat(event.getType(), is(EventType.LEVEL_WON));
-        assertThat((Boolean)event.getEventData().get("won"), is(true));
+        assertNotNull(event);
+        assertEquals(EventType.LEVEL_WON, event.getType());
+        assertTrue((Boolean)event.getEventData().get("won"));
     }
     
     @Test
@@ -82,13 +81,13 @@ public class LevelWinListenerAdapterTest {
         adapter.lost();
         
         // Assert
-        assertThat(originalListener.wonCalled, is(false));
-        assertThat(originalListener.lostCalled, is(true));
+        assertFalse(originalListener.wonCalled);
+        assertTrue(originalListener.lostCalled);
         
         GameEvent event = eventListener.getLastEvent();
-        assertThat(event, is(notNullValue()));
-        assertThat(event.getType(), is(EventType.LEVEL_LOST));
-        assertThat((Boolean)event.getEventData().get("won"), is(false));
+        assertNotNull(event);
+        assertEquals(EventType.LEVEL_LOST, event.getType());
+        assertFalse((Boolean)event.getEventData().get("won"));
     }
     
     @Test
@@ -98,9 +97,9 @@ public class LevelWinListenerAdapterTest {
         
         // Act & Assert - should not throw exception
         adapter.won();
-        assertThat(eventListener.getLastEvent().getType(), is(EventType.LEVEL_WON));
+        assertEquals(EventType.LEVEL_WON, eventListener.getLastEvent().getType());
         
         adapter.lost();
-        assertThat(eventListener.getLastEvent().getType(), is(EventType.LEVEL_LOST));
+        assertEquals(EventType.LEVEL_LOST, eventListener.getLastEvent().getType());
     }
 }

--- a/src/engine/test/rabbitescape/engine/events/LevelWinListenerAdapterTest.java
+++ b/src/engine/test/rabbitescape/engine/events/LevelWinListenerAdapterTest.java
@@ -1,0 +1,130 @@
+package rabbitescape.engine.events;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
+import org.junit.Test;
+import rabbitescape.engine.LevelWinListener;
+
+public class LevelWinListenerAdapterTest {
+    
+    private static class TestLevelWinListener implements LevelWinListener {
+        private boolean wonCalled = false;
+        private boolean lostCalled = false;
+        
+        @Override
+        public void won() {
+            wonCalled = true;
+        }
+        
+        @Override
+        public void lost() {
+            lostCalled = true;
+        }
+        
+        public void reset() {
+            wonCalled = false;
+            lostCalled = false;
+        }
+    }
+    
+    private static class TestGameEventListener implements GameEventListener {
+        private GameEvent lastEvent = null;
+        
+        @Override
+        public void onGameEvent(GameEvent event) {
+            lastEvent = event;
+        }
+        
+        public GameEvent getLastEvent() {
+            return lastEvent;
+        }
+        
+        public void reset() {
+            lastEvent = null;
+        }
+    }
+    
+    @Test
+    public void won_shouldCallOriginalListenerAndFireEvent() {
+        // Arrange
+        GameEventManager eventManager = new GameEventManager();
+        TestLevelWinListener originalListener = new TestLevelWinListener();
+        TestGameEventListener eventListener = new TestGameEventListener();
+        LevelWinListenerAdapter adapter = new LevelWinListenerAdapter(originalListener, eventManager);
+        
+        eventManager.addEventListener(EventType.LEVEL_WON, eventListener);
+        
+        // Act
+        adapter.won();
+        
+        // Assert
+        assertThat(originalListener.wonCalled, is(true));
+        assertThat(originalListener.lostCalled, is(false));
+        
+        assertThat(eventListener.getLastEvent(), is(notNullValue()));
+        assertThat(eventListener.getLastEvent().getType(), is(EventType.LEVEL_WON));
+        assertThat((Boolean)eventListener.getLastEvent().getEventData().get("won"), is(true));
+    }
+    
+    @Test
+    public void lost_shouldCallOriginalListenerAndFireEvent() {
+        // Arrange
+        GameEventManager eventManager = new GameEventManager();
+        TestLevelWinListener originalListener = new TestLevelWinListener();
+        TestGameEventListener eventListener = new TestGameEventListener();
+        LevelWinListenerAdapter adapter = new LevelWinListenerAdapter(originalListener, eventManager);
+        
+        eventManager.addEventListener(EventType.LEVEL_LOST, eventListener);
+        
+        // Act
+        adapter.lost();
+        
+        // Assert
+        assertThat(originalListener.wonCalled, is(false));
+        assertThat(originalListener.lostCalled, is(true));
+        
+        assertThat(eventListener.getLastEvent(), is(notNullValue()));
+        assertThat(eventListener.getLastEvent().getType(), is(EventType.LEVEL_LOST));
+        assertThat((Boolean)eventListener.getLastEvent().getEventData().get("won"), is(false));
+    }
+    
+    @Test
+    public void adapter_shouldWorkWithNullOriginalListener() {
+        // Arrange
+        GameEventManager eventManager = new GameEventManager();
+        TestGameEventListener eventListener = new TestGameEventListener();
+        LevelWinListenerAdapter adapter = new LevelWinListenerAdapter(null, eventManager);
+        
+        eventManager.addEventListener(EventType.LEVEL_WON, eventListener);
+        eventManager.addEventListener(EventType.LEVEL_LOST, eventListener);
+        
+        // Act & Assert - should not throw exception
+        adapter.won();
+        assertThat(eventListener.getLastEvent().getType(), is(EventType.LEVEL_WON));
+        
+        adapter.lost();
+        assertThat(eventListener.getLastEvent().getType(), is(EventType.LEVEL_LOST));
+    }
+    
+    @Test
+    public void events_shouldContainCorrectData() {
+        // Arrange
+        GameEventManager eventManager = new GameEventManager();
+        TestGameEventListener eventListener = new TestGameEventListener();
+        LevelWinListenerAdapter adapter = new LevelWinListenerAdapter(null, eventManager);
+        
+        eventManager.addEventListener(EventType.LEVEL_WON, eventListener);
+        eventManager.addEventListener(EventType.LEVEL_LOST, eventListener);
+        
+        // Act & Assert for win
+        adapter.won();
+        assertThat(eventListener.getLastEvent().getEventData().containsKey("won"), is(true));
+        assertThat((Boolean)eventListener.getLastEvent().getEventData().get("won"), is(true));
+        
+        // Act & Assert for loss
+        adapter.lost();
+        assertThat(eventListener.getLastEvent().getEventData().containsKey("won"), is(true));
+        assertThat((Boolean)eventListener.getLastEvent().getEventData().get("won"), is(false));
+    }
+}

--- a/src/engine/test/rabbitescape/engine/events/LevelWinListenerAdapterTest.java
+++ b/src/engine/test/rabbitescape/engine/events/LevelWinListenerAdapterTest.java
@@ -1,12 +1,17 @@
 package rabbitescape.engine.events;
 
+import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
-
+import org.junit.Before;
 import org.junit.Test;
 import rabbitescape.engine.LevelWinListener;
 
 public class LevelWinListenerAdapterTest {
+    
+    private GameEventManager eventManager;
+    private TestLevelWinListener originalListener;
+    private TestGameEventListener eventListener;
+    private LevelWinListenerAdapter adapter;
     
     private static class TestLevelWinListener implements LevelWinListener {
         private boolean wonCalled = false;
@@ -45,16 +50,19 @@ public class LevelWinListenerAdapterTest {
         }
     }
     
-    @Test
-    public void won_shouldCallOriginalListenerAndFireEvent() {
-        // Arrange
-        GameEventManager eventManager = new GameEventManager();
-        TestLevelWinListener originalListener = new TestLevelWinListener();
-        TestGameEventListener eventListener = new TestGameEventListener();
-        LevelWinListenerAdapter adapter = new LevelWinListenerAdapter(originalListener, eventManager);
+    @Before
+    public void setUp() {
+        eventManager = new GameEventManager();
+        originalListener = new TestLevelWinListener();
+        eventListener = new TestGameEventListener();
+        adapter = new LevelWinListenerAdapter(originalListener, eventManager);
         
         eventManager.addEventListener(EventType.LEVEL_WON, eventListener);
-        
+        eventManager.addEventListener(EventType.LEVEL_LOST, eventListener);
+    }
+    
+    @Test
+    public void won_shouldCallOriginalListenerAndFireEvent() {
         // Act
         adapter.won();
         
@@ -62,21 +70,14 @@ public class LevelWinListenerAdapterTest {
         assertThat(originalListener.wonCalled, is(true));
         assertThat(originalListener.lostCalled, is(false));
         
-        assertThat(eventListener.getLastEvent(), is(notNullValue()));
-        assertThat(eventListener.getLastEvent().getType(), is(EventType.LEVEL_WON));
-        assertThat((Boolean)eventListener.getLastEvent().getEventData().get("won"), is(true));
+        GameEvent event = eventListener.getLastEvent();
+        assertThat(event, is(notNullValue()));
+        assertThat(event.getType(), is(EventType.LEVEL_WON));
+        assertThat((Boolean)event.getEventData().get("won"), is(true));
     }
     
     @Test
     public void lost_shouldCallOriginalListenerAndFireEvent() {
-        // Arrange
-        GameEventManager eventManager = new GameEventManager();
-        TestLevelWinListener originalListener = new TestLevelWinListener();
-        TestGameEventListener eventListener = new TestGameEventListener();
-        LevelWinListenerAdapter adapter = new LevelWinListenerAdapter(originalListener, eventManager);
-        
-        eventManager.addEventListener(EventType.LEVEL_LOST, eventListener);
-        
         // Act
         adapter.lost();
         
@@ -84,20 +85,16 @@ public class LevelWinListenerAdapterTest {
         assertThat(originalListener.wonCalled, is(false));
         assertThat(originalListener.lostCalled, is(true));
         
-        assertThat(eventListener.getLastEvent(), is(notNullValue()));
-        assertThat(eventListener.getLastEvent().getType(), is(EventType.LEVEL_LOST));
-        assertThat((Boolean)eventListener.getLastEvent().getEventData().get("won"), is(false));
+        GameEvent event = eventListener.getLastEvent();
+        assertThat(event, is(notNullValue()));
+        assertThat(event.getType(), is(EventType.LEVEL_LOST));
+        assertThat((Boolean)event.getEventData().get("won"), is(false));
     }
     
     @Test
     public void adapter_shouldWorkWithNullOriginalListener() {
         // Arrange
-        GameEventManager eventManager = new GameEventManager();
-        TestGameEventListener eventListener = new TestGameEventListener();
-        LevelWinListenerAdapter adapter = new LevelWinListenerAdapter(null, eventManager);
-        
-        eventManager.addEventListener(EventType.LEVEL_WON, eventListener);
-        eventManager.addEventListener(EventType.LEVEL_LOST, eventListener);
+        adapter = new LevelWinListenerAdapter(null, eventManager);
         
         // Act & Assert - should not throw exception
         adapter.won();
@@ -105,26 +102,5 @@ public class LevelWinListenerAdapterTest {
         
         adapter.lost();
         assertThat(eventListener.getLastEvent().getType(), is(EventType.LEVEL_LOST));
-    }
-    
-    @Test
-    public void events_shouldContainCorrectData() {
-        // Arrange
-        GameEventManager eventManager = new GameEventManager();
-        TestGameEventListener eventListener = new TestGameEventListener();
-        LevelWinListenerAdapter adapter = new LevelWinListenerAdapter(null, eventManager);
-        
-        eventManager.addEventListener(EventType.LEVEL_WON, eventListener);
-        eventManager.addEventListener(EventType.LEVEL_LOST, eventListener);
-        
-        // Act & Assert for win
-        adapter.won();
-        assertThat(eventListener.getLastEvent().getEventData().containsKey("won"), is(true));
-        assertThat((Boolean)eventListener.getLastEvent().getEventData().get("won"), is(true));
-        
-        // Act & Assert for loss
-        adapter.lost();
-        assertThat(eventListener.getLastEvent().getEventData().containsKey("won"), is(true));
-        assertThat((Boolean)eventListener.getLastEvent().getEventData().get("won"), is(false));
     }
 }

--- a/src/engine/test/rabbitescape/engine/events/TestGameEvent.java
+++ b/src/engine/test/rabbitescape/engine/events/TestGameEvent.java
@@ -7,8 +7,12 @@ import java.util.Map;
  * A simple GameEvent implementation for testing purposes.
  */
 public class TestGameEvent implements GameEvent {
-    private final EventType type;
-    private final String testData;
+    private EventType type;
+    private String testData;
+
+    public TestGameEvent() {
+        this(EventType.RABBIT_MOVED, "default");
+    }
 
     public TestGameEvent(EventType type, String testData) {
         this.type = type;
@@ -32,5 +36,13 @@ public class TestGameEvent implements GameEvent {
 
     public String getTestData() {
         return testData;
+    }
+
+    public void setType(EventType type) {
+        this.type = type;
+    }
+
+    public void setTestData(String testData) {
+        this.testData = testData;
     }
 }

--- a/src/engine/test/rabbitescape/engine/events/TestGameEvent.java
+++ b/src/engine/test/rabbitescape/engine/events/TestGameEvent.java
@@ -1,0 +1,30 @@
+package rabbitescape.engine.events;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestGameEvent implements GameEvent {
+    private final EventType type;
+    private final String testData;
+
+    public TestGameEvent(EventType type, String testData) {
+        this.type = type;
+        this.testData = testData;
+    }
+
+    @Override
+    public EventType getType() {
+        return type;
+    }
+
+    @Override
+    public Map<String, Object> getEventData() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("testData", testData);
+        return data;
+    }
+
+    public String getTestData() {
+        return testData;
+    }
+}

--- a/src/engine/test/rabbitescape/engine/events/TestGameEvent.java
+++ b/src/engine/test/rabbitescape/engine/events/TestGameEvent.java
@@ -3,6 +3,9 @@ package rabbitescape.engine.events;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * A simple GameEvent implementation for testing purposes.
+ */
 public class TestGameEvent implements GameEvent {
     private final EventType type;
     private final String testData;
@@ -21,6 +24,9 @@ public class TestGameEvent implements GameEvent {
     public Map<String, Object> getEventData() {
         Map<String, Object> data = new HashMap<>();
         data.put("testData", testData);
+        if (type == EventType.LEVEL_WON || type == EventType.LEVEL_LOST) {
+            data.put("won", type == EventType.LEVEL_WON);
+        }
         return data;
     }
 

--- a/src/engine/test/rabbitescape/engine/events/TestGameEvent.java
+++ b/src/engine/test/rabbitescape/engine/events/TestGameEvent.java
@@ -11,12 +11,8 @@ public class TestGameEvent implements GameEvent {
     private String testData;
 
     public TestGameEvent() {
-        this(EventType.RABBIT_MOVED, "default");
-    }
-
-    public TestGameEvent(EventType type, String testData) {
-        this.type = type;
-        this.testData = testData;
+        this.type = EventType.RABBIT_MOVED;
+        this.testData = "default";
     }
 
     @Override


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #9 

# 📝 작업 내용

> GameEvent 인터페이스를 통해 LevelStatsChangedEvent와 RabbitEvent, StatsChangedEvent를 정의하고 World에 적용하였습니다.
> 테스트코드에 문제가 있는데, 이부분은 아직 작업하지 않았습니다. 추후 해결되면 연결되는 PR 작성하겠습니다.

## 참고 이미지 및 자료
> ![Observer Pattern Structure](https://refactoring.guru/images/patterns/diagrams/observer/structure.png)

# 💬 리뷰 요구사항

> 건드리면 건드릴수록 테스트코드가 오버엔지니어링이 되기도 하고, 문제가 쌓이고 쌓여가는 느낌이네요.
> 가상의 이벤트를 구현하는 TestGameEvent 클래스가 말썽인데, test 경로 내에 있어서 그런 것 같아 다른 디렉토리에 정의하려고 합니다.
> 생각해둔것은 MockGameEvent로 이름을 변경하고, 테스트코드에서 참조하도록 하려고 하는데, 올바른 방향일까요? 더 좋은 방법이 있다면 의견 부탁드립니다.
