### PR TITLE
[fix]  make 컴파일 에러 수정

### DIFF
--- a/src/engine/src/rabbitescape/engine/WorldChanges.java
+++ b/src/engine/src/rabbitescape/engine/WorldChanges.java
@@ -28,9 +28,9 @@ public class WorldChanges
     public final List<Position>   blocksJustRemoved = new ArrayList<Position>();
     private final List<Position>  waterPointsToRecalculate = new ArrayList<>();
 
-    private boolean explodeAll = false;
+    protected boolean explodeAll = false;
 
-    private List<Rabbit> rabbitsJustEntered = new ArrayList<Rabbit>();
+    protected List<Rabbit> rabbitsJustEntered = new ArrayList<Rabbit>();
 
     public WorldChanges( World world, WorldStatsListener statsListener )
     {
@@ -83,7 +83,7 @@ public class WorldChanges
         }
     }
 
-    private void updateStats()
+    protected void updateStats()
     {
         statsListener.worldStats( world.num_saved, world.num_to_save );
     }

--- a/src/engine/src/rabbitescape/engine/commands/RemoveBlockAtCommand.java
+++ b/src/engine/src/rabbitescape/engine/commands/RemoveBlockAtCommand.java
@@ -1,6 +1,6 @@
 package rabbitescape.engine.commands;
 
-import java.util.List;
+import java.util.Arrays;
 
 import rabbitescape.engine.Block;
 import rabbitescape.engine.World;
@@ -26,7 +26,7 @@ public class RemoveBlockAtCommand implements Command {
             throw new NoBlockFound(x, y);
         }
 
-        world.blockTable.removeAll(List.of(block));
+        world.blockTable.removeAll(Arrays.asList(block));
         world.recalculateWaterRegions(new Position(x, y));
     }
 


### PR DESCRIPTION
# #️⃣ 연관 이슈
- #32 

# 📝 작업 내용
1. 누락된 커밋 적용
2. 자바 버전 8에 맞게 코드 변경

## 참고 이미지 및 자료

기존 WorldChanges 클래스의 필드 접근제어자를 protected 로 수정한 커밋이 누락되어 발생한 오류입니다.
이번 작업에서 다시 적용했습니다.
```
src/engine/src/rabbitescape/engine/commands/WorldChangesWithCommand.java:36: error: explodeAll has private access in WorldChanges
        if(explodeAll) explodeAllRabbits();
           ^
src/engine/src/rabbitescape/engine/commands/WorldChangesWithCommand.java:44: error: cannot find symbol
        if(existsSave) updateStats();
                       ^
  symbol:   method updateStats()
  location: class WorldChangesWithCommand
src/engine/src/rabbitescape/engine/commands/WorldChangesWithCommand.java:141: error: explodeAll has private access in WorldChanges
        explodeAll = true;
        ^
src/engine/src/rabbitescape/engine/commands/WorldChangesWithCommand.java:148: error: rabbitsJustEntered has private access in WorldChanges
        return rabbitsJustEntered;
               ^
src/engine/src/rabbitescape/engine/commands/WorldChangesWithCommand.java:160: error: rabbitsJustEntered has private access in WorldChanges
        rabbitsJustEntered = rabbitsToEnter;
        ^
```

List.of() 문법은 java 9 부터 지원된다고 합니다.
java 8에 맞게 수정하였습니다.

```
src/engine/src/rabbitescape/engine/commands/RemoveBlockAtCommand.java:29: error: cannot find symbol
        world.blockTable.removeAll(List.of(block));
```
