### PR TITLE
[hotfix] TestGithubIssue 잘못된 표현 수정

### DIFF
--- a/src/ui-swing/test/rabbitescape/ui/swing/TestGitHubIssue.java
+++ b/src/ui-swing/test/rabbitescape/ui/swing/TestGitHubIssue.java
@@ -2,7 +2,8 @@ package rabbitescape.ui.swing;
 
 import org.junit.Before;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 import rabbitescape.ui.swing.state.BugIssueState;
 import rabbitescape.ui.swing.state.LevelIssueState;
@@ -22,27 +23,27 @@ public class TestGitHubIssue {
 
     @Test
     public void defaultStateTest() {
-        assertThat(issue.getStateType()).equals(StateUtil.STATE_DEFAULT);
+        assertThat(issue.getStateType(), is(StateUtil.STATE_DEFAULT));
     }
 
     @Test
     public void bugStateTest() {
-        // Given
+        // When
         GitHubIssue bugIssue = new GitHubIssue(TEST_ISSUE_NUMBER, TEST_TITLE, TEST_BODY, 
             new String[]{"bug"});
 
         // Then
-        assertThat(issue.getStateType()).equals(StateUtil.STATE_BUG);
+        assertThat(bugIssue.getStateType(), is(StateUtil.STATE_BUG));
     }
 
     @Test
     public void levelStateTest() {
-        // Given
+        // When
         GitHubIssue levelIssue = new GitHubIssue(TEST_ISSUE_NUMBER, TEST_TITLE, TEST_BODY, 
             new String[]{"level"});
 
         // Then
-        assertThat(issue.getStateType()).equals(StateUtil.STATE_LEVEL);
+        assertThat(levelIssue.getStateType(), is(StateUtil.STATE_LEVEL));
     }
 
     @Test
@@ -51,7 +52,7 @@ public class TestGitHubIssue {
         issue.setState(new BugIssueState());
 
         // Then
-        assertThat(issue.getStateType()).equals(StateUtil.STATE_BUG);
+        assertThat(issue.getStateType(), is(StateUtil.STATE_BUG));
     }
 
     @Test
@@ -60,40 +61,35 @@ public class TestGitHubIssue {
         issue.setState(new LevelIssueState());
 
         // Then
-        assertThat(issue.getStateType()).equals(StateUtil.STATE_LEVEL);
+        assertThat(issue.getStateType(), is(StateUtil.STATE_LEVEL));
     }
 
     @Test
     public void changeToDefaultStateTest() {
-        // Given
-        issue.setState(new BugIssueState());
-        
         // When
         issue.setState(new DefaultIssueState());
 
         // Then
-        assertThat(issue.getStateType()).equals(StateUtil.STATE_DEFAULT);
+        assertThat(issue.getStateType(), is(StateUtil.STATE_DEFAULT));
     }
 
     @Test
     public void changeToLevelStateWithMultiLabelTest() {
-        // Given
+        // When
         GitHubIssue multiLabelIssue = new GitHubIssue(TEST_ISSUE_NUMBER, TEST_TITLE, TEST_BODY, 
             new String[]{"bug", "level"});
 
         // Then
-        assertThat(issue.getStateType()).equals(StateUtil.STATE_LEVEL);
+        assertThat(multiLabelIssue.getStateType(), is(StateUtil.STATE_LEVEL));
     }
 
     @Test
     public void nullCouldNotChangeStateTest() {
-        // Given
-        issue.setState(new BugIssueState());
-        
         // When
+        issue.setState(new BugIssueState());
         issue.setState(null);
 
         // Then
-        assertThat(issue.getStateType()).equals(StateUtil.STATE_BUG);
+        assertThat(issue.getStateType(), is(StateUtil.STATE_BUG));
     }
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #11 

# 📝 작업 내용

> AssertJ 라이브러리를 참고하던 TestGithubIssue가 실제 테스트 실행 과정에서 실행되지 않는 버그가 있었습니다.
> 
> 시간이 없어 기존 테스트 라이브러리로 전면 교체하고 일부 표현을 수정했습니다.


## 참고 이미지 및 자료

# 💬 리뷰 요구사항

